### PR TITLE
Function_id is in result pass back up

### DIFF
--- a/src/msg/mod.rs
+++ b/src/msg/mod.rs
@@ -86,12 +86,7 @@ impl FfaMsg {
         let params: FfaParams = self.into();
         let result = ffa_smc(params);
 
-        match self.function_id {
-            FfaFunctionId::FfaMsgSendDirectReq | FfaFunctionId::FfaMsgSendDirectReq2 => {
-                result.try_into().map_err(|_| FfaError::UnknownError)
-            }
-            FfaFunctionId::FfaError => Err(FfaError::InvalidParameters),
-            _ => panic!("Unknown FfaFunctionId {:?}", self.function_id),
-        }
+        // Return FfaMsg or error to caller
+        result.try_into().map_err(|_| FfaError::UnknownError)
     }
 }


### PR DESCRIPTION
self.function_id is not updated so it will still be the value we called exec with.

The function_id is checked by the caller so just try to convert the result to FfaMsg or return failure if it fails up to the caller.